### PR TITLE
Update tileSourcesPrefix url

### DIFF
--- a/openseadragoncollectiontester/index.html
+++ b/openseadragoncollectiontester/index.html
@@ -12,7 +12,7 @@
     <div id="osd1" class="openseadragon1"></div>
 
     <script type="text/javascript">
-        var tileSourcesPrefix = '../openseadragonimaging/data/',
+        var tileSourcesPrefix = '../openseadragon-imaging/demo/data/',
         //var tileSourcesPrefix = '/media/openseadragonsamples/',
             tileSources = [
                 tileSourcesPrefix + 'testpattern.dzi',

--- a/openseadragonmultitester/index.html
+++ b/openseadragonmultitester/index.html
@@ -81,7 +81,7 @@
 
         <script type="text/javascript">
 
-            var tileSourcesPrefix = '../openseadragonimaging/data/';
+            var tileSourcesPrefix = '../openseadragon-imaging/demo/data/';
             //var tileSourcesPrefix = '/media/openseadragonsamples/';
 
             function getOpacity( layerName ) {

--- a/openseadragontester/index.html
+++ b/openseadragontester/index.html
@@ -14,7 +14,7 @@
     <div id="osd1" class="openseadragon1"></div>
 
     <script type="text/javascript">
-        var tileSourcesPrefix = '../openseadragonimaging/data/',
+        var tileSourcesPrefix = '../openseadragon-imaging/demo/data/',
         //var tileSourcesPrefix = '/media/openseadragonsamples/',
             tileSources = [
                 tileSourcesPrefix + 'testpattern.dzi',


### PR DESCRIPTION
Hi @msalsbery.  I came across [your build](https://msalsbery.github.io/openseadragonmultitester/index.html) of avandercreme's layers demo while looking at issue [389](https://github.com/openseadragon/openseadragon/issues/389).  I went to run the example for a visual.  And I realized that the tileSourcesPrefix url was broken.  I fixed it. :). Hope it's OK with you.